### PR TITLE
Add grunt server task for easy development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,4 +78,5 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('default', ['less', 'html2js', 'concat', 'uglify']);
+  grunt.registerTask('server', ['connect', 'watch'])
 };


### PR DESCRIPTION
## What does this PR do?

Adds a `server` task for easier development.
Just use `grunt server` to have a server running and watching the files.